### PR TITLE
Listen on shared queues by supplying the queue owner's acct number

### DIFF
--- a/multi_sqs_listener/_long_polling.py
+++ b/multi_sqs_listener/_long_polling.py
@@ -32,7 +32,11 @@ class _LongPollSQSListener(Thread):
         self._queue_name = queue_name
         self._handler_available_event = handler_available_event
         sqs = boto3.resource('sqs', region_name=self._region_name)
-        self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
+        if self._queue_acct_id is not None:
+            self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
+        else:
+            self._queue = sqs.get_queue_by_name(QueueName=self._queue_name)
+
 
         self._run_event = run_event
 

--- a/multi_sqs_listener/_long_polling.py
+++ b/multi_sqs_listener/_long_polling.py
@@ -27,11 +27,13 @@ class _LongPollSQSListener(Thread):
         Thread.__init__(self, name=queue_name)
         self.thread_id = thread_id
         self._region_name = kwargs['region_name'] if 'region_name' in kwargs else 'eu-west-1'
+        self._queue_acct_id = kwargs.get('queue_acct_id')
         self._outbound_bus = outbound_bus
         self._queue_name = queue_name
         self._handler_available_event = handler_available_event
         sqs = boto3.resource('sqs', region_name=self._region_name)
-        self._queue = sqs.get_queue_by_name(QueueName=self._queue_name)
+        self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
+
         self._run_event = run_event
 
         logger.debug('Starting up thread {} and long-polling inbound queue {}'.format(

--- a/multi_sqs_listener/_short_polling.py
+++ b/multi_sqs_listener/_short_polling.py
@@ -34,7 +34,11 @@ class _ShortPollSQSListener(Thread):
         self._poll_interval = poll_interval
         self._handler_available_event = handler_available_event
         sqs = boto3.resource('sqs', region_name=self._region_name)
-        self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
+        if self._queue_acct_id is not None:
+            self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
+        else:
+            self._queue = sqs.get_queue_by_name(QueueName=self._queue_name)
+
         self._run_event = run_event
 
         logger.debug('Starting up thread {} and short-polling inbound queue {}'.format(

--- a/multi_sqs_listener/_short_polling.py
+++ b/multi_sqs_listener/_short_polling.py
@@ -28,12 +28,13 @@ class _ShortPollSQSListener(Thread):
         Thread.__init__(self, name=queue_name)
         self.thread_id = thread_id
         self._region_name = kwargs['region_name'] if 'region_name' in kwargs else 'eu-west-1'
+        self._queue_acct_id = kwargs.get('queue_acct_id')
         self._outbound_bus = outbound_bus
         self._queue_name = queue_name
         self._poll_interval = poll_interval
         self._handler_available_event = handler_available_event
         sqs = boto3.resource('sqs', region_name=self._region_name)
-        self._queue = sqs.get_queue_by_name(QueueName=self._queue_name)
+        self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
         self._run_event = run_event
 
         logger.debug('Starting up thread {} and short-polling inbound queue {}'.format(

--- a/multi_sqs_listener/config.py
+++ b/multi_sqs_listener/config.py
@@ -23,6 +23,7 @@ class QueueConfig(object):
         self.bus = bus
         self.queue_type = kwargs['queue_type'] if 'queue_type' in kwargs else 'long-poll'
         self.region_name = kwargs['region_name'] if 'region_name' in kwargs else 'eu-west-1'
+        self.queue_acct_id = kwargs.get('queue_acct_id')
 
         # Only for short polling queues
         self.poll_interval = kwargs['poll_interval'] if 'poll_interval' in kwargs else 60

--- a/multi_sqs_listener/multi_sqs_listener.py
+++ b/multi_sqs_listener/multi_sqs_listener.py
@@ -47,7 +47,8 @@ class MultiSQSListener(object):
                     queue.bus.get(),
                     run_event,
                     handler_available_event,
-                    region_name=queue.region_name
+                    region_name=queue.region_name,
+                    queue_acct_id=queue.queue_acct_id
                 )
             else:
                 listener_thread = _ShortPollSQSListener(
@@ -57,7 +58,8 @@ class MultiSQSListener(object):
                     run_event,
                     handler_available_event,
                     queue.poll_interval,
-                    region_name=queue.region_name
+                    region_name=queue.region_name,
+                    queue_acct_id=queue.queue_acct_id
                 )
             listener_thread.start()
             threads.append(listener_thread)


### PR DESCRIPTION
This PR (hopefully) satisfies issue #1 - support an SQS client listening to a queue that is owned by another AWS account. To use, just supply an optional parameter to `QueueConfig`, for example:

```
sqs_queue1 = QueueConfig('another-accounts-queue', external_event_bus, queue_type='long-poll', region_name='ap-southeast-2', queue_acct_id='1234567890')
```

Note that both the queue owner and queue listener must have setup correct IAM permissions to support cross-account SQS access. See the docs here:
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-customer-managed-policy-examples.html
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-authentication-and-access-control.html