### PR TITLE
For use with localstack, endpoint_url should be specified

### DIFF
--- a/multi_sqs_listener/_long_polling.py
+++ b/multi_sqs_listener/_long_polling.py
@@ -32,10 +32,7 @@ class _LongPollSQSListener(Thread):
         self._outbound_bus = outbound_bus
         self._queue_name = queue_name
         self._handler_available_event = handler_available_event
-        if self._endpoint_url is not None:
-            sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
-        else:
-            sqs = boto3.resource('sqs', region_name=self._region_name)
+        sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
         if self._queue_acct_id is not None:
             self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
         else:

--- a/multi_sqs_listener/_long_polling.py
+++ b/multi_sqs_listener/_long_polling.py
@@ -28,10 +28,14 @@ class _LongPollSQSListener(Thread):
         self.thread_id = thread_id
         self._region_name = kwargs['region_name'] if 'region_name' in kwargs else 'eu-west-1'
         self._queue_acct_id = kwargs.get('queue_acct_id')
+        self._endpoint_url = kwargs.get('endpoint_url')
         self._outbound_bus = outbound_bus
         self._queue_name = queue_name
         self._handler_available_event = handler_available_event
-        sqs = boto3.resource('sqs', region_name=self._region_name)
+        if self._endpoint_url is not None:
+            sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
+        else
+            sqs = boto3.resource('sqs', region_name=self._region_name)
         if self._queue_acct_id is not None:
             self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
         else:

--- a/multi_sqs_listener/_long_polling.py
+++ b/multi_sqs_listener/_long_polling.py
@@ -34,7 +34,7 @@ class _LongPollSQSListener(Thread):
         self._handler_available_event = handler_available_event
         if self._endpoint_url is not None:
             sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
-        else
+        else:
             sqs = boto3.resource('sqs', region_name=self._region_name)
         if self._queue_acct_id is not None:
             self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)

--- a/multi_sqs_listener/_short_polling.py
+++ b/multi_sqs_listener/_short_polling.py
@@ -34,10 +34,7 @@ class _ShortPollSQSListener(Thread):
         self._queue_name = queue_name
         self._poll_interval = poll_interval
         self._handler_available_event = handler_available_event
-        if self._endpoint_url is not None:
-            sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
-        else:
-            sqs = boto3.resource('sqs', region_name=self._region_name)
+        sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
         if self._queue_acct_id is not None:
             self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
         else:

--- a/multi_sqs_listener/_short_polling.py
+++ b/multi_sqs_listener/_short_polling.py
@@ -29,11 +29,15 @@ class _ShortPollSQSListener(Thread):
         self.thread_id = thread_id
         self._region_name = kwargs['region_name'] if 'region_name' in kwargs else 'eu-west-1'
         self._queue_acct_id = kwargs.get('queue_acct_id')
+        self._endpoint_url = kwargs.get('endpoint_url')
         self._outbound_bus = outbound_bus
         self._queue_name = queue_name
         self._poll_interval = poll_interval
         self._handler_available_event = handler_available_event
-        sqs = boto3.resource('sqs', region_name=self._region_name)
+        if self._endpoint_url is not None:
+            sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
+        else
+            sqs = boto3.resource('sqs', region_name=self._region_name)
         if self._queue_acct_id is not None:
             self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)
         else:

--- a/multi_sqs_listener/_short_polling.py
+++ b/multi_sqs_listener/_short_polling.py
@@ -36,7 +36,7 @@ class _ShortPollSQSListener(Thread):
         self._handler_available_event = handler_available_event
         if self._endpoint_url is not None:
             sqs = boto3.resource('sqs', region_name=self._region_name, endpoint_url=self._endpoint_url)
-        else
+        else:
             sqs = boto3.resource('sqs', region_name=self._region_name)
         if self._queue_acct_id is not None:
             self._queue = sqs.get_queue_by_name(QueueName=self._queue_name, QueueOwnerAWSAccountId=self._queue_acct_id)

--- a/multi_sqs_listener/config.py
+++ b/multi_sqs_listener/config.py
@@ -24,6 +24,7 @@ class QueueConfig(object):
         self.queue_type = kwargs['queue_type'] if 'queue_type' in kwargs else 'long-poll'
         self.region_name = kwargs['region_name'] if 'region_name' in kwargs else 'eu-west-1'
         self.queue_acct_id = kwargs.get('queue_acct_id')
+        self.endpoint_url = kwargs.get('endpoint_url')
 
         # Only for short polling queues
         self.poll_interval = kwargs['poll_interval'] if 'poll_interval' in kwargs else 60

--- a/multi_sqs_listener/multi_sqs_listener.py
+++ b/multi_sqs_listener/multi_sqs_listener.py
@@ -48,7 +48,8 @@ class MultiSQSListener(object):
                     run_event,
                     handler_available_event,
                     region_name=queue.region_name,
-                    queue_acct_id=queue.queue_acct_id
+                    queue_acct_id=queue.queue_acct_id,
+                    endpoint_url=queue.endpoint_url
                 )
             else:
                 listener_thread = _ShortPollSQSListener(
@@ -59,7 +60,8 @@ class MultiSQSListener(object):
                     handler_available_event,
                     queue.poll_interval,
                     region_name=queue.region_name,
-                    queue_acct_id=queue.queue_acct_id
+                    queue_acct_id=queue.queue_acct_id,
+                    endpoint_url=queue.endpoint_url
                 )
             listener_thread.start()
             threads.append(listener_thread)

--- a/multi_sqs_listener/multi_sqs_listener.py
+++ b/multi_sqs_listener/multi_sqs_listener.py
@@ -76,6 +76,7 @@ class MultiSQSListener(object):
                         message = bus.get().get(block=False)
                         handler_available_event.clear()
                         try:
+                            logger.info("Message received - {}".format(message[0])) 
                             self.handle_message(message[0], bus.name, bus.priority, message[1])
                             a_message_was_processed = True
                             # If handle message worked, then delete the message from SQS


### PR DESCRIPTION
Added in the option to specify endpoint_url for a queue.

Example:
`my_queue = QueueConfig('my-queue', my_event_bus, queue_acct_id='000000000000', endpoint_url='http://localhost:4566')`

This is a typical usage for localstack for SQS and other various AWS tools running on local machine:
https://github.com/localstack/localstack